### PR TITLE
Update langchain version and related VertexAI libraries to be imported

### DIFF
--- a/Lab 5 - Parsing Data/parsing-data.ipynb
+++ b/Lab 5 - Parsing Data/parsing-data.ipynb
@@ -28,8 +28,8 @@
     "%pip install --user \"langchain==0.1.20\"\n",
     "%pip install --user gradio\n",
     "%pip install --user IProgress\n",
-    "%pip install --user tqdm"
-    "%pip install --user langchain-community"
+    "%pip install --user tqdm\n"
+    "%pip install --user langchain-community\n"
     "%pip install --user langchain-google-vertexai"
    ]
   },

--- a/Lab 5 - Parsing Data/parsing-data.ipynb
+++ b/Lab 5 - Parsing Data/parsing-data.ipynb
@@ -29,6 +29,8 @@
     "%pip install --user gradio\n",
     "%pip install --user IProgress\n",
     "%pip install --user tqdm"
+    "%pip install --user langchain-community"
+    "%pip install --user langchain-google-vertexai"
    ]
   },
   {

--- a/Lab 5 - Parsing Data/parsing-data.ipynb
+++ b/Lab 5 - Parsing Data/parsing-data.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "%pip install --user graphdatascience\n",
     "%pip install --user \"pydantic==1.10.11\"\n",
-    "%pip install --user \"langchain==0.0.310\"\n",
+    "%pip install --user \"langchain==0.1.20\"\n",
     "%pip install --user gradio\n",
     "%pip install --user IProgress\n",
     "%pip install --user tqdm"

--- a/Lab 5 - Parsing Data/parsing-data.ipynb
+++ b/Lab 5 - Parsing Data/parsing-data.ipynb
@@ -28,8 +28,8 @@
     "%pip install --user \"langchain==0.1.20\"\n",
     "%pip install --user gradio\n",
     "%pip install --user IProgress\n",
-    "%pip install --user tqdm\n"
-    "%pip install --user langchain-community\n"
+    "%pip install --user tqdm\n",
+    "%pip install --user langchain-community\n",
     "%pip install --user langchain-google-vertexai"
    ]
   },

--- a/Lab 6 - Chatbot/chatbot.ipynb
+++ b/Lab 6 - Chatbot/chatbot.ipynb
@@ -245,7 +245,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.graphs import Neo4jGraph\n",
+    "from langchain_community.graphs import Neo4jGraph\n",
     "\n",
     "graph = Neo4jGraph(\n",
     "    url=NEO4J_URI, \n",

--- a/Lab 6 - Chatbot/chatbot.ipynb
+++ b/Lab 6 - Chatbot/chatbot.ipynb
@@ -27,7 +27,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.llms import VertexAI\n",
+    "from langchain_google_vertexai import VertexAI\n",
     "\n",
     "base_chain = VertexAI(model_name='text-bison', max_output_tokens=2048, temperature=0)"
    ]

--- a/Lab 6 - Chatbot/chatbot.ipynb
+++ b/Lab 6 - Chatbot/chatbot.ipynb
@@ -287,7 +287,7 @@
     ")\n",
     "\n",
     "def chat(que):\n",
-    "    r = chain(que)\n",
+    "    r = chain.invoke(que)\n",
     "    print(r)\n",
     "    llm=VertexAI(model_name='text-bison', max_output_tokens=2048, temperature=0.0)\n",
     "    summary_prompt_tpl = f\"\"\"Human: \n",


### PR DESCRIPTION
Langchain is now running v0.1.20 while the code is still on 0.0.310 which is quite old. Additionally with the Langchain version update, some VertexAI libraries got deprecated and are to be utilized in a differently as suggested in the PR.