### PR TITLE
Set share=False for Gradio interface to avoid security warnings

### DIFF
--- a/Lab 6 - Chatbot/chatbot.ipynb
+++ b/Lab 6 - Chatbot/chatbot.ipynb
@@ -504,7 +504,7 @@
     "                                         \"Who are the common investors between Tesla and Costco?\",\n",
     "                                         \"Who are Tesla's top investors in last 48 months?\"])\n",
     "\n",
-    "interface.launch(share=True)"
+    "interface.launch()"
    ]
   },
   {


### PR DESCRIPTION
Thank you for the excellent hands-on material — it was extremely helpful and informative.

That said, I noticed that the chatbot code has share=True set in the gradio configuration. When I ran it as-is, Windows Defender flagged it, and I ended up getting a warning from our IT department.

Since I believe this hands-on will continue to be useful for many people over time, I suggest setting share=False by default to avoid similar issues. I'm sending this PR with that adjustment.